### PR TITLE
make page tags wrap to fix overflow on small screens

### DIFF
--- a/src/lib/MDLayout.svelte
+++ b/src/lib/MDLayout.svelte
@@ -44,7 +44,7 @@
   {/if}
   {@render children()}
   {#if tags}
-    <div class="bg-stone-950/40 p-2 rounded-lg flex items-center space-x-3 my-10">
+    <div class="bg-stone-950/40 p-2 rounded-lg flex items-center flex-wrap gap-3 my-10">
       <span class="uppercase text-sm text-zinc-500">Tags:</span>
       {#each tagsArr as tag}
         <span class="border border-yellow-500 px-1 text-yellow-500 rounded-lg uppercase text-sm">{tag}</span>


### PR DESCRIPTION
On small screens the page tags overflow which looks terrible. This fixes it