### PR TITLE
Fix load.mcfunction in player-id-system guide

### DIFF
--- a/src/routes/guide/nbt-and-scores/player-id-system/+page.svx
+++ b/src/routes/guide/nbt-and-scores/player-id-system/+page.svx
@@ -14,8 +14,8 @@ Firstly, we need to create a scoreboard objective to store the players' IDs. Thi
 # Create the playerid scoreboard
 scoreboard objectives add playerid dummy
 
-# Set the max score on the playerid scoreboard to 1
-scoreboard players set .max playerid 1
+# Set the max score on the playerid scoreboard to 1, unless already set
+execute unless score .max playerid matches 1.. run scoreboard players set .max playerid 1
 ```
 
 Next, we need to assign an ID to the player when they first join the world. Create a function which increments the max player ID by one, and then assigns that value to the player.


### PR DESCRIPTION
The `.max` would be set to 1 on every load (which can run multiple times, for example every time a server restarts), so i made it only set it to 1 if its not set 1 or above yet.