### PR TITLE
Update contribution guides & add common parameters

### DIFF
--- a/src/routes/contribute/formatting/+page.svx
+++ b/src/routes/contribute/formatting/+page.svx
@@ -36,7 +36,7 @@ When writing, **try** to follow these guidelines:
 
 1. Use the active voice. For example, instead of `The pig is teleported by the command`, write `The command teleported the pig`.
 2. Don't use unnecessary adverbs or adjectives
-3. Don't use the words: _obvious, simple, basic, easy, actual, just, clear,_ and _however_
+3. Try not to use the words: _obvious, simple, basic, easy, actual, just, clear,_ and _however_
 4. Explicitly reference what you are explaining
 5. Use `'s` for indicating possession
 6. Use the [Oxford comma](https://simple.wikipedia.org/wiki/Serial_comma)

--- a/src/routes/contribute/git-practices/+page.svx
+++ b/src/routes/contribute/git-practices/+page.svx
@@ -7,43 +7,34 @@ description: "This page is an introduction to our Git practices a page for the w
 
 **Last Updated:** 12-13-2024
 
-This page is an introduction to how we use Git in the wiki repository. In order to keep the wiki consistent and
+This page is an introduction to how we use Git in the [wiki repository](https://github.com/Datapack-Hub/wiki). In order to keep the wiki consistent and
 reputable, we have a few rules that we follow.
 
 Git provides a lot of features that are great for collaboration, and we try to use them as much as possible.
 
-## Branching and PRs
+:::info
+This guide assumes you already have experience using Git before.
+:::
 
-Branches are a great way to work on the wiki without introducing unfinished pages, changes, etc. Branches allow you to
-work on a page without affecting the main (production) branch and allow us to review your changes before they are
-merged.
+## Forking and PRs
 
-### Branch Naming
-
-We use `kebab-case` for branch names meaning the branch name should be all lowercase with hyphens to
-separate words. For example, if you are working on a page called "Adding New Features", the branch name should be
-`adding-new-features`.
-
-### Branch Workflow
-
-When you are ready to merge your changes into the main branch, create a pull request (PR) and assign it to a
-reviewer. The reviewer will review your changes and either approve or request changes. Once approved, the changes will
-be merged into the main branch.
-
-We recommend deleting the branch after it has been merged into the main branch. This will keep the repository clean and
-reduce confusion. An exception to this is if you are working on a very large feature that will take a while to merge, or
-if you plan to merge multiple features from one branch.
-
-## Forking
-
-Forking is another way to work on the wiki without affecting the main branch. This is useful if you are a first-time
-contributor and don't have write access. You can click the "Fork" button in the top right corner of the repository to
-create a fork of the repository. This will create a copy of the repository that you can work on.
+Forks are a great way to work on the wiki without introducing unfinished pages, changes, etc. to main.
+You can click the ["Fork"](https://github.com/Datapack-Hub/wiki/fork) button in the top right corner of the repository to
+create a fork of the repository. This will create a complete copy of the repository that you can work on.
 
 Once you have forked the repository, you can clone it to your local machine.
 
-When it comes time to merge your changes, you can create a pull request in the same way as you would with a branch, just
-replace the branch name with the name of your fork's branch name.
+When it comes time to merge your changes, you can create a pull request, and a wiki contributor will review your contribution.
+
+## Branches
+
+Branches are useful additions to help separate features in your fork. We use `kebab-case` for branch names meaning the branch 
+name should be all lowercase with hyphens to separate words. For example, if you are working on a page called "Adding New Features", 
+the branch name should be `adding-new-features`.
+
+We do not recommend you use branches for the main repository, even if you have permissions to. 
+Branches in the repository are mainly for upcoming Minecraft versions or huge upcoming reworks, if you believe you 
+have a reason to add a branch to the main repository, let a wiki admin know.
 
 ## Commit Messages
 
@@ -63,7 +54,7 @@ Whenever you start working on a new branch or features, pull the latest changes 
 will ensure that you have the most up-to-date changes.
 
 You will likely run into an issue with the `search.json` file, which is used to generate the search index. This file is
-generated automatically and should not be manually edited. A solution to this is to remove the `search.json` file and
+generated automatically and should not be manually edited. A solution to this is to remove the `search.json` file and optionally
 run the search index generation script. This will regenerate the file and you can commit it.
 
 ```
@@ -76,8 +67,6 @@ bun ./gen_search_indexes.js
 
 ## Other Important Information
 
-- Always use the `main` branch as the base branch for your PRs. This will reduce the chances of conflicts and ensure
-  that your changes are merged correctly.
 - Make a description of your changes in your PR.
 - Reviewers: Proofread changes before approving them.
 - Reviewers: It's not required, but it's recommended the changes follow American English for consistency sake.

--- a/src/routes/wiki/command/all/+page.svx
+++ b/src/routes/wiki/command/all/+page.svx
@@ -12,10 +12,20 @@ We use the following syntax to make it easier to understand which arguments are 
 | Variable                 | Meaning                                                                            |
 | ------------------------ | ---------------------------------------------------------------------------------- |
 | `<argumentName>`         | An argument.                                                                       |
-| `[<entry>]`                | An optional entry.                                                                 |
+| `[<entry>]`              | An optional entry.                                                                 |
 | `<entryA│entryB│entryC>` | Pick one of these. This is required.                                               |
 | `[entryA│entryB│entryC]` | Pick one of these. This is optional.                                               |
 | `...`                    | Some syntax is left out, you can find more about the command on its dedicated page |
+
+## Common Parameters
+
+Parameters that show up commonly
+
+| Variable                 | Meaning                                                                            |
+| ------------------------ | ---------------------------------------------------------------------------------- |
+| `target(s)`              | A [Target Selector](https://datapack.wiki/wiki/concepts/target-selectors).         |
+| `range`                  | A [Range](https://datapack.wiki/wiki/concepts/ranges).                             |
+| `time`                   | Indicates time (`1s` = 1 second, `1t` = 1 game tick)                               |
 
 ## List of commands by Permission Level
 
@@ -29,7 +39,7 @@ These commands can be run by any player, no matter their permission level.
 - `/seed` - Displays the world's seed, permission level 0 only in singleplayer
 - `/teammsg <message>` - Sends a message to all players in the same team of the command runner. (Alias `/tm`)
 - `/me <message>` - Displays: `* <Player's Name> <message>` in chat
-- `/msg <targets> <message>` - Sends a private message to a player. (Alias `/tell` and `/w`)
+- `/msg <player> <message>` - Sends a private message to a player. (Alias `/tell` and `/w`)
 - `/trigger <objective> [add|set] [<value>]` - Triggers a scoreboard objective (see [Scoreboards](/wiki/nbt-scoreboards/scoreboards#trigger-objectives))
 
 ### Permission level 1


### PR DESCRIPTION
This PR fixes some criticisms with the contribution guide and adds a table of some common parameters and their wiki pages to the all commands list. 

This should reduce confusion for newer users, however in the future a "how to rely less on external sources" page may be thought up to reduce the reliance on these hard-to-update pages

I did these pretty quick so expect and point out any errors that may have appeared.