### PR TITLE
Update pack_format for Getting Started guide

### DIFF
--- a/src/routes/guide/getting-started/+page.svx
+++ b/src/routes/guide/getting-started/+page.svx
@@ -62,7 +62,7 @@ as well as holding the basic information of the pack. **Create `pack.mcmeta`, an
 {
   "pack": {
     "description": "DATAPACK NAME HERE",
-    "pack_format": 71
+    "pack_format": 80
   }
 }
 ```
@@ -71,7 +71,7 @@ If you're interested, here's what this file means:
 
 - `pack` is an object containing the metadata of the file.
   - `description` is the name of your datapack, usually along with a short description of what your pack does.
-  - `pack_format` tells Minecraft what versions this datapack works in. `71` is the latest for 1.21.5
+  - `pack_format` tells Minecraft what versions this datapack works in. `80` is the latest for 1.21.6
 
 ## Writing your first function
 


### PR DESCRIPTION
The page was partially updated for 1.21.6 with 078f751, but the pack_format wasn't updated to 80.