### PR TITLE
Added missing closing curly bracket

### DIFF
--- a/src/routes/guide/right-click/eoe/+page.svx
+++ b/src/routes/guide/right-click/eoe/+page.svx
@@ -29,7 +29,7 @@ To detect when an eye of ender is being used, you must create a `using_item` adv
           ],
           "predicates": {
             "minecraft:custom_data": {"custom_id": "your_custom_item_id"}
-            
+          }
         }
       }
     }


### PR DESCRIPTION
On the Eye of Ender RC detection page, there is a missing curly bracket (accidentally removed in #34).