### PR TITLE
rewrite forking in page about execute

### DIFF
--- a/src/routes/wiki/command/execute/+page.svx
+++ b/src/routes/wiki/command/execute/+page.svx
@@ -24,8 +24,10 @@ run. The context includes:
 
 ## Forking
 
-Some commands cause a fork. That is, the following chain of subcommands get executed more than once. When a command is
-forked, it executes the fork as a whole, then proceeds to the next fork.
+Some subcommands can split the command execution into multiple branches. This
+is called forking. This means any subcommands that follow will be executed
+multiple times, once for each branch. Minecraft will finish executing all
+subcommands in the first branch before moving on to the next.
 
 For example, if there are two markers A and B, and the following command is run:
 `execute as @e[type=marker] run function example`  


### PR DESCRIPTION
former explaination confuses terms. fork was used as both the forking and the branch. but subcommand "forks" when creates multiple branches of execution, and the term branch was missed.

source: https://minecraft.wiki/w/Commands/execute#Subcommands_and_forking

correct terminology is very important for explaining other topics, such as the sub tick, optimization, id system and possibly even more.