### PR TITLE
New Guide: Get default item components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -319,9 +319,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -337,9 +334,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -357,9 +351,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -375,9 +366,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -395,9 +383,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -413,9 +398,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -813,9 +795,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -831,9 +810,6 @@
       "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -851,9 +827,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -869,9 +842,6 @@
       "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1884,9 +1854,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1906,9 +1873,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -1930,9 +1894,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1952,9 +1913,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src/lib/sidebar/tabs/latest/Guides.svelte
+++ b/src/lib/sidebar/tabs/latest/Guides.svelte
@@ -5,7 +5,7 @@
   import SidebarHeading from "$lib/sidebar/navigation/SidebarHeading.svelte";
 
   // Icon imports
-  // https://tabler-icons.io
+  // https://tabler.io
   // import Icon<whatever name> from "~icons/tabler/<icon ID>"
   import IconHome from "~icons/tabler/home";
   import IconPennant from "~icons/tabler/pennant";
@@ -44,6 +44,7 @@
   import IconCat from "~icons/tabler/cat";
   import IconBaguette from "~icons/tabler/baguette";
   import SidebarPlaceholder from "../../navigation/SidebarPlaceholder.svelte";
+  import IconPick from '~icons/tabler/IconPick';
 </script>
 
 <!-- ADD PAGES AND CATEGORIES BELOW -->
@@ -66,10 +67,7 @@
   <SidebarHeading label="Custom Items" />
   <SidebarPage label="Introduction" icon={IconItem} page="/guide/adding-new-features/custom-items/intro" />
   <SidebarPage label="Custom Item Recipes" icon={IconGrid} page="/guide/adding-new-features/custom-items/crafting" />
-  <SidebarPage
-    label="Custom Item Models and Textures"
-    icon={IconPhotoPlus}
-    page="/guide/adding-new-features/custom-items/models" />
+  <SidebarPage label="Custom Item Models and Textures" icon={IconPhotoPlus} page="/guide/adding-new-features/custom-items/models" />
 </SidebarCategory>
 
 <SidebarCategory name="Right Click Detection" icon={IconMouse}>
@@ -88,6 +86,7 @@
   <SidebarPage label="Player ID System" icon={IconID} page="/guide/nbt-and-scores/player-id-system" />
   <SidebarPage label="Floating Point Division" icon={IconDivide} page="/guide/nbt-and-scores/division" />
   <SidebarPage label="Array Iteration" icon={IconList} page="/guide/nbt-and-scores/array-iteration" />
+  <SidebarPage label="Get Default Item Components" icon={IconPick} page="/guide/nbt-and-scores/get-default-item-components" />
 </SidebarCategory>
 
 <SidebarCategory name="Performance" icon={IconBrandSpeedtest}>

--- a/src/lib/sidebar/tabs/latest/Guides.svelte
+++ b/src/lib/sidebar/tabs/latest/Guides.svelte
@@ -44,7 +44,7 @@
   import IconCat from "~icons/tabler/cat";
   import IconBaguette from "~icons/tabler/baguette";
   import SidebarPlaceholder from "../../navigation/SidebarPlaceholder.svelte";
-  import IconPick from '~icons/tabler/IconPick';
+  import IconPick from '~icons/tabler/pick';
 </script>
 
 <!-- ADD PAGES AND CATEGORIES BELOW -->
@@ -86,7 +86,7 @@
   <SidebarPage label="Player ID System" icon={IconID} page="/guide/nbt-and-scores/player-id-system" />
   <SidebarPage label="Floating Point Division" icon={IconDivide} page="/guide/nbt-and-scores/division" />
   <SidebarPage label="Array Iteration" icon={IconList} page="/guide/nbt-and-scores/array-iteration" />
-  <SidebarPage label="Get Default Item Components" icon={IconPick} page="/guide/nbt-and-scores/get-default-item-components" />
+  <SidebarPage label="Default Item Components" icon={IconPick} page="/guide/nbt-and-scores/get-default-item-components" />
 </SidebarCategory>
 
 <SidebarCategory name="Performance" icon={IconBrandSpeedtest}>

--- a/src/routes/credits/+page.svx
+++ b/src/routes/credits/+page.svx
@@ -39,6 +39,7 @@ These people have written or edited pages for the wiki or guides.
 - Kraggle09
 - Amandin
 - Subzeroditto
+- theblackswitch
 
 :::note
 

--- a/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
+++ b/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
@@ -63,7 +63,7 @@ You must also provide a position but this is unsed in our loot table so it can b
 
 ### Read any slot
 
-To make this work for any slot, we need to summon an armor stand (which has a mainhand slot) and copy the desired item to said slot.
+The problem with reading from any slot is that there is no slot other than the mainhand which we could use to provide the "tool" context. To solve this issue, we need to summon an armor stand and copy the desired item to it. This works because the armor stand has a mainhand slot and thus allows it to provide the "tool" context.
 
 ```mcfunction:get_default_components/init.mcfunction
 # Tag the player here so we can find it without the execution context

--- a/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
+++ b/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
@@ -7,14 +7,14 @@ version: 26.2
 ---
 
 # Get default item components
-This method will explain how to get the default **data components** (sometimes reffered to as ``item components``) from an item. 
+This method will explain how to get the default **data components** (sometimes referred to as `item components`) from an item. 
 Not to confuse with the bedrock [item components](https://minecraft.wiki/w/Item_components)
 
-The method is centered around the ``minecraft:copy_components`` loot table function which will copy the components from a source to the item. This **includes** the default components. This is not only really cool but also pretty optimized too.
+The method is centered around the `minecraft:copy_components` loot table function which will copy the components from a source to the item. This **includes** the default components. This is not only really cool but also pretty optimized too.
 
 ## Method
 
-To start, we make a loot table that drops a dummy item and applies the ``copy_components`` loot function.
+To start, we make a loot table that drops a dummy item and applies the `copy_components` loot function.
 
 ```json:copy_default_components.json
 {
@@ -32,9 +32,9 @@ To start, we make a loot table that drops a dummy item and applies the ``copy_co
 }
 ```
 
-The source here is the only problem. It can only refrence a ``block_entity``, an entity from context (like ``this``) or a ``tool``. 
+The source here is the only problem. It can only reference a `block_entity`, an entity from context (like `this`) or a `tool`. 
 
-We'll use ``tool`` here since that's the only way to pass an _item_ to the function. This means we need to provide said context to the loot table so it knows what the "tool" is. This is best done using the ``minecraft:fishing`` loot context as this allows us to pass the mainhand item as a "tool" context.
+We'll use `tool` here since that's the only way to pass an _item_ to the function. This means we need to provide said context to the loot table so it knows what the "tool" is. This is best done using the `minecraft:fishing` loot context as this allows us to pass the mainhand item as a "tool" context.
 
 ```json:copy_default_components.json
 {
@@ -53,7 +53,7 @@ We'll use ``tool`` here since that's the only way to pass an _item_ to the funct
 }
 ```
 
-Now we can use the command ``loot replace entity @s weapon.offhand fish example:copy_default_components ~ ~ ~ mainhand`` Which will provide the mainhand slot as a "tool" context. 
+Now we can use the command `loot replace entity @s weapon.offhand fish example:copy_default_components ~ ~ ~ mainhand` Which will provide the mainhand slot as a "tool" context. 
 
 :::info
 
@@ -87,9 +87,9 @@ data modify storage example:temp default_components set from entity @s equipment
 kill @s
 ```
 
-Voila, now we only need to run the function ``example:get_default_components/init`` to get the components from the chosen slot (in this case the head slot).
+Voila, now we only need to run the function `example:get_default_components/init` to get the components from the chosen slot (in this case the head slot).
 
-In addition, you can also filter for any components using the ``include`` and ``exclude`` fields in your loot table. 
+In addition, you can also filter for any components using the `include` and `exclude` fields in your loot table. 
 ```json
 {
   "function": "minecraft:copy_components",

--- a/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
+++ b/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
@@ -7,34 +7,15 @@ version: 26.2
 ---
 
 # Get default item components
-This method will explain how to get the default **data components** (commonly referred to as item components) from an item. 
-Not to confuse with the bedrock [item components](https://minecraft.wiki/w/Item_components)
+This method will explain how to get the default **data components** (commonly referred to as item components) from an item. These default components are usually hidden from a datapack but aquiring them can be really useful. We could for namespace use this to read the `max_stack_size` from any item.
 
-The method is centered around the `minecraft:copy_components` loot table function which will copy the components from a source to the item. This **includes** the default components. This is not only really cool but also pretty optimized too.
+The method relies on the `minecraft:copy_components` loot table function which will copy the components from a source to the item. This also **includes** the (hidden) default components, allowing us to "reveal" them. This is not only really cool but also pretty optimized too.
 
 ## Method
 
-To start, we make a loot table that drops a dummy item and applies the `copy_components` loot function.
+To start, we make a loot table that drops a dummy item and applies the `copy_components` loot function. This function requires a source to copy the components from. This, unfortunatly, can only be one of `block_entity`, any entity from context (for namespace `this` or `attacker`) or a `tool`. The only source that can be an item is `tool` so we'll use that. 
 
-```json:copy_default_components.json
-{
-	"pools": [{
-		"rolls": 1,
-		"entries": [{
-			"type": "minecraft:item",
-			"name": "minecraft:poisonous_potato",
-			"functions": [{
-				"function": "minecraft:copy_components",
-				"source": "???"
-			}]
-		}]
-	}]
-}
-```
-
-The source here is the only problem. It can only reference a `block_entity`, an entity from context (like `this`) or a `tool`. 
-
-We'll use `tool` here since that's the only way to pass an _item_ to the function. This means we need to provide said context to the loot table so it knows what the "tool" is. This is best done using the `minecraft:fishing` loot context as this allows us to pass the mainhand item as a "tool" context.
+Now we need to "tell" the loot table what the `tool` is. This can be done through [loot context](https://minecraft.wiki/w/Loot_context). In this case we'll use fishing loot context.
 
 ```json:copy_default_components.json
 {
@@ -53,41 +34,60 @@ We'll use `tool` here since that's the only way to pass an _item_ to the functio
 }
 ```
 
-Now we can use the command `loot replace entity @s weapon.offhand fish example:copy_default_components ~ ~ ~ mainhand` Which will provide the mainhand slot as a "tool" context. 
+The fishing loot context allows us to use the `mainhand` slot as a `tool`. This leads us to the following command:
+```mcfunction
+loot replace entity @s weapon.offhand fish namespace:copy_default_components ~ ~ ~ mainhand
+```
+
+This command will place a dummy item (from the loot table) into the player's offhand slot.  (Since we don't want to replace the offhand slot or any other inventory slot, we'll have to summon a temporary entity to store the dummy item. More on that later.)
+
+Next, the loot table will also copy all components from the item in the `mainhand` to the dummy item in the offhand slot, even the default (hidden) components.
 
 :::info
 
-You must also provide a position but this is unsed in our loot table so it can be any value.
+The `/loot` command requires a position when you access a fishing-type loot table. In our case, this can be any position since we're not using said context.
 
 :::
 
 ### Read any slot
 
-The problem with reading from any slot is that there is no slot other than the mainhand which we could use to provide the "tool" context. To solve this issue, we need to summon an armor stand and copy the desired item to it. This works because the armor stand has a mainhand slot and thus allows it to provide the "tool" context.
+Unfortunately, Minecraft only lets us use the `mainhand` slot as "tool" context. If we want to read from any slot, we need a small workaround.
+
+To solve both this issue and the slot issue, we can summon a temporary armor stand. 
 
 ```mcfunction:get_default_components/init.mcfunction
 # Tag the player here so we can find it without the execution context
 tag @s add target_player 
-execute summon minecraft:armor_stand run function example:get_default_components/summon 
+execute summon minecraft:armor_stand run function namespace:get_default_components/summon 
 tag @s remove target_player
 ```
 
-```mcfunction:get_default_components/summon.mcfunction
+Next we copy the desired item to it's mainhand. After that, we can use this mainhand slot to provide the "tool" context and copy the dummy item to it's offhand.
+
+Now the only thing we need to do is read the data from the armorstand and kill it.
+
+```mcfunction:get_default_components/process.mcfunction
 # Move the item from the desired player slot onto the armor stand
-$item replace entity @s weapon.mainhand from entity @a[tag=target_player] armor.head
+item replace entity @s weapon.mainhand from entity @a[tag=target_player] armor.head
 
 # Copy the components to a default item
-loot replace entity @s weapon.offhand fish example:get_default_components ~ ~ ~ mainhand
+loot replace entity @s weapon.offhand fish namespace:get_default_components ~ ~ ~ mainhand
 
 # Copy the components to a result storage
-data remove storage example:temp default_components
-data modify storage example:temp default_components set from entity @s equipment.offhand.components
+data remove storage namespace:temp default_components
+data modify storage namespace:temp default_components set from entity @s equipment.offhand.components
 
 # Kill the armor stand
 kill @s
 ```
 
-Voila, now we only need to run the function `example:get_default_components/init` to get the components from the chosen slot (in this case the head slot).
+Voila, now we can run the function `namespace:get_default_components/init` to get the components from the chosen slot (in this case the head slot).
+
+:::tip
+
+The source slot can be changed by modifying `armor.head` on line 2. The data components will be stored to the `namespace:default_components` storage in NBT format
+
+:::
 
 In addition, you can also filter for any components using the `include` and `exclude` fields in your loot table. 
 ```json
@@ -100,8 +100,6 @@ In addition, you can also filter for any components using the `include` and `exc
 }
 ```
 
-I assume this might be a little more performant than copying all components and then selecting a single component using data get but more benchmarking is needed here.
+## Credits
 
-### Credits
-
-This method was originally discovered by [baphomet42](https://discord.com/channels/154777837382008833/157097006500806656/1418032607215620096) and finalized by [Arkiitekk](https://discord.com/channels/935560260725379143/1435909929754955796/1538472517558083624) who informed me about it. Hence I decided to make a guide for this awesome datapack quirk.
+This method was originally discovered by [baphomet42 on the Minecraft Commands discord server](https://discord.com/channels/154777837382008833/157097006500806656/1418032607215620096) and finalized by [Arkiitekk](https://discord.com/channels/935560260725379143/1435909929754955796/1538472517558083624) who informed me about it. Hence I decided to make a guide for this awesome datapack quirk.

--- a/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
+++ b/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
@@ -6,7 +6,7 @@ description:
 version: 26.2
 ---
 
-# Get default item components
+# Get Default Item Components
 This method will explain how to get the default **data components** (commonly referred to as item components) from an item. These default components are usually hidden from a datapack but aquiring them can be really useful. We could, for example, use this to read the `max_stack_size` from any item.
 
 The method relies on the `minecraft:copy_components` loot table function which copies item components from a source item, but also **includes** the (hidden) default components. We can use this functionality in a datapack to easily access the default components of any item.
@@ -53,7 +53,7 @@ The `/loot` command requires a position when you access a fishing-type loot tabl
 
 Unfortunately, Minecraft only lets us use the `mainhand` slot as "tool" context. If we want to read from any slot, we need a small workaround.
 
-To solve both this issue and the slot issue, we can summon a temporary armor stand. 
+To solve both this issue and the target slot issue (explained in the previous section), we can summon a temporary armor stand. 
 
 ```mcfunction:get_default_components/init.mcfunction
 # Tag the player here so we can find it without the execution context
@@ -95,8 +95,6 @@ In addition, you can also filter for or filter out any components using the `inc
 ```
 
 :::
-
-
 
 ## Credits
 

--- a/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
+++ b/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
@@ -7,13 +7,13 @@ version: 26.2
 ---
 
 # Get default item components
-This method will explain how to get the default **data components** (commonly referred to as item components) from an item. These default components are usually hidden from a datapack but aquiring them can be really useful. We could for namespace use this to read the `max_stack_size` from any item.
+This method will explain how to get the default **data components** (commonly referred to as item components) from an item. These default components are usually hidden from a datapack but aquiring them can be really useful. We could for example use this to read the `max_stack_size` from any item.
 
 The method relies on the `minecraft:copy_components` loot table function which will copy the components from a source to the item. This also **includes** the (hidden) default components, allowing us to "reveal" them. This is not only really cool but also pretty optimized too.
 
 ## Method
 
-To start, we make a loot table that drops a dummy item and applies the `copy_components` loot function. This function requires a source to copy the components from. This, unfortunatly, can only be one of `block_entity`, any entity from context (for namespace `this` or `attacker`) or a `tool`. The only source that can be an item is `tool` so we'll use that. 
+To start, we make a loot table that drops a dummy item and applies the `copy_components` loot function. This function requires a source to copy the components from. This, unfortunatly, can only be one of `block_entity`, any entity from context (for example `this` or `attacker`) or a `tool`. The only source that can be an item is `tool` so we'll use that. 
 
 Now we need to "tell" the loot table what the `tool` is. This can be done through [loot context](https://minecraft.wiki/w/Loot_context). In this case we'll use fishing loot context.
 

--- a/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
+++ b/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
@@ -7,7 +7,7 @@ version: 26.2
 ---
 
 # Get default item components
-This method will explain how to get the default **data components** (sometimes referred to as `item components`) from an item. 
+This method will explain how to get the default **data components** (commonly referred to as item components) from an item. 
 Not to confuse with the bedrock [item components](https://minecraft.wiki/w/Item_components)
 
 The method is centered around the `minecraft:copy_components` loot table function which will copy the components from a source to the item. This **includes** the default components. This is not only really cool but also pretty optimized too.

--- a/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
+++ b/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
@@ -1,5 +1,5 @@
 ---
-title: Right Click Detection Summary
+title: Get default item components
 description:
   This section explains how you would collect the default data components from an item using a
   Minecraft datapack.
@@ -7,19 +7,14 @@ version: 26.2
 ---
 
 # Get default item components
-This method will explain how to get the default **data components** from an item. 
-
-:::info
-
-Not to confuse with [item components](https://minecraft.wiki/w/Item_components) which are a bedrock feature
-
-:::
+This method will explain how to get the default **data components** (sometimes reffered to as ``item components``) from an item. 
+Not to confuse with the bedrock [item components](https://minecraft.wiki/w/Item_components)
 
 The method is centered around the ``minecraft:copy_components`` loot table function which will copy the components from a source to the item. This **includes** the default components. This is not only really cool but also pretty optimized too.
 
 ## Method
 
-To start, we make a loot table that drops a dummy item and applies this loot function.
+To start, we make a loot table that drops a dummy item and applies the ``copy_components`` loot function.
 
 ```json:copy_default_components.json
 {
@@ -37,9 +32,9 @@ To start, we make a loot table that drops a dummy item and applies this loot fun
 }
 ```
 
-The source here is a bit of a problem since it can only refrence a ``block_entity``, an entity from context or a ``tool``. 
+The source here is the only problem. It can only refrence a ``block_entity``, an entity from context (like ``this``) or a ``tool``. 
 
-We'll use ``tool`` here since that's the only way to pass an **item** to the function. This means we need to provide said context to the loot table. This is best done using the ``minecraft:fishing`` loot context.
+We'll use ``tool`` here since that's the only way to pass an _item_ to the function. This means we need to provide said context to the loot table so it knows what the "tool" is. This is best done using the ``minecraft:fishing`` loot context as this allows us to pass the mainhand item as a "tool" context.
 
 ```json:copy_default_components.json
 {
@@ -58,7 +53,13 @@ We'll use ``tool`` here since that's the only way to pass an **item** to the fun
 }
 ```
 
-Now we can use the command ``loot ... fish example:copy_default_components ~ ~ ~ mainhand`` Which will provide the mainhand slot as context for the tool.
+Now we can use the command ``loot replace entity @s weapon.offhand fish example:copy_default_components ~ ~ ~ mainhand`` Which will provide the mainhand slot as a "tool" context. 
+
+:::info
+
+You must also provide a position but this is unsed in our loot table so it can be any value.
+
+:::
 
 ### Read any slot
 
@@ -88,7 +89,8 @@ kill @s
 
 Voila, now we only need to run the function ``example:get_default_components/init`` to get the components from the chosen slot (in this case the head slot).
 
-In addition, you can also filter for any components using the ``include`` and ``exclude`` fields ```json
+In addition, you can also filter for any components using the ``include`` and ``exclude`` fields in your loot table. 
+```json
 {
   "function": "minecraft:copy_components",
   "source": "tool",
@@ -98,10 +100,8 @@ In addition, you can also filter for any components using the ``include`` and ``
 }
 ```
 
-I assume this might be a little more performant than copying all components and then only selecting a single one using data get.
+I assume this might be a little more performant than copying all components and then selecting a single component using data get but more benchmarking is needed here.
 
-:::info
+### Credits
 
-This method was originally discovered by [baphomet42](https://discord.com/channels/154777837382008833/157097006500806656/1418032607215620096) and finalized by [Arkiitekk](https://discord.com/channels/935560260725379143/1435909929754955796/1538472517558083624) who informed me about this method. Hence I decided to make a guide about this awesome datapack quirk.
-
-:::
+This method was originally discovered by [baphomet42](https://discord.com/channels/154777837382008833/157097006500806656/1418032607215620096) and finalized by [Arkiitekk](https://discord.com/channels/935560260725379143/1435909929754955796/1538472517558083624) who informed me about it. Hence I decided to make a guide for this awesome datapack quirk.

--- a/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
+++ b/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
@@ -1,0 +1,107 @@
+---
+title: Right Click Detection Summary
+description:
+  This section explains how you would collect the default data components from an item using a
+  Minecraft datapack.
+version: 26.2
+---
+
+# Get default item components
+This method will explain how to get the default **data components** from an item. 
+
+:::info
+
+Not to confuse with [item components](https://minecraft.wiki/w/Item_components) which are a bedrock feature
+
+:::
+
+The method is centered around the ``minecraft:copy_components`` loot table function which will copy the components from a source to the item. This **includes** the default components. This is not only really cool but also pretty optimized too.
+
+## Method
+
+To start, we make a loot table that drops a dummy item and applies this loot function.
+
+```json:copy_default_components.json
+{
+	"pools": [{
+		"rolls": 1,
+		"entries": [{
+			"type": "minecraft:item",
+			"name": "minecraft:poisonous_potato",
+			"functions": [{
+				"function": "minecraft:copy_components",
+				"source": "???"
+			}]
+		}]
+	}]
+}
+```
+
+The source here is a bit of a problem since it can only refrence a ``block_entity``, an entity from context or a ``tool``. 
+
+We'll use ``tool`` here since that's the only way to pass an **item** to the function. This means we need to provide said context to the loot table. This is best done using the ``minecraft:fishing`` loot context.
+
+```json:copy_default_components.json
+{
+    "type": "minecraft:fishing",
+	"pools": [{
+		"rolls": 1,
+		"entries": [{
+			"type": "minecraft:item",
+			"name": "minecraft:poisonous_potato",
+			"functions": [{
+				"function": "minecraft:copy_components",
+				"source": "tool"
+			}]
+		}]
+	}]
+}
+```
+
+Now we can use the command ``loot ... fish example:copy_default_components ~ ~ ~ mainhand`` Which will provide the mainhand slot as context for the tool.
+
+### Read any slot
+
+To make this work for any slot, we need to summon an armor stand (which has a mainhand slot) and copy the desired item to said slot.
+
+```mcfunction:get_default_components/init.mcfunction
+# Tag the player here so we can find it without the execution context
+tag @s add target_player 
+execute summon minecraft:armor_stand run function example:get_default_components/summon 
+tag @s remove target_player
+```
+
+```mcfunction:get_default_components/summon.mcfunction
+# Move the item from the desired player slot onto the armor stand
+$item replace entity @s weapon.mainhand from entity @a[tag=target_player] armor.head
+
+# Copy the components to a default item
+loot replace entity @s weapon.offhand fish example:get_default_components ~ ~ ~ mainhand
+
+# Copy the components to a result storage
+data remove storage example:temp default_components
+data modify storage example:temp default_components set from entity @s equipment.offhand.components
+
+# Kill the armor stand
+kill @s
+```
+
+Voila, now we only need to run the function ``example:get_default_components/init`` to get the components from the chosen slot (in this case the head slot).
+
+In addition, you can also filter for any components using the ``include`` and ``exclude`` fields ```json
+{
+  "function": "minecraft:copy_components",
+  "source": "tool",
+  "include": [
+    "minecraft:max_stack_size"
+  ]
+}
+```
+
+I assume this might be a little more performant than copying all components and then only selecting a single one using data get.
+
+:::info
+
+This method was originally discovered by [baphomet42](https://discord.com/channels/154777837382008833/157097006500806656/1418032607215620096) and finalized by [Arkiitekk](https://discord.com/channels/935560260725379143/1435909929754955796/1538472517558083624) who informed me about this method. Hence I decided to make a guide about this awesome datapack quirk.
+
+:::

--- a/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
+++ b/src/routes/guide/nbt-and-scores/get-default-item-components/+page.svx
@@ -7,9 +7,9 @@ version: 26.2
 ---
 
 # Get default item components
-This method will explain how to get the default **data components** (commonly referred to as item components) from an item. These default components are usually hidden from a datapack but aquiring them can be really useful. We could for namespace use this to read the `max_stack_size` from any item.
+This method will explain how to get the default **data components** (commonly referred to as item components) from an item. These default components are usually hidden from a datapack but aquiring them can be really useful. We could, for example, use this to read the `max_stack_size` from any item.
 
-The method relies on the `minecraft:copy_components` loot table function which will copy the components from a source to the item. This also **includes** the (hidden) default components, allowing us to "reveal" them. This is not only really cool but also pretty optimized too.
+The method relies on the `minecraft:copy_components` loot table function which copies item components from a source item, but also **includes** the (hidden) default components. We can use this functionality in a datapack to easily access the default components of any item.
 
 ## Method
 
@@ -39,9 +39,9 @@ The fishing loot context allows us to use the `mainhand` slot as a `tool`. This 
 loot replace entity @s weapon.offhand fish namespace:copy_default_components ~ ~ ~ mainhand
 ```
 
-This command will place a dummy item (from the loot table) into the player's offhand slot.  (Since we don't want to replace the offhand slot or any other inventory slot, we'll have to summon a temporary entity to store the dummy item. More on that later.)
+This command will place a dummy item (from the loot table) into the player's offhand slot. (Since we don't want to replace the offhand slot or any other inventory slot, we'll have to summon a temporary entity to store the dummy item. More on that later.) Then, the loot table will also copy all components from the item in the `mainhand` to the dummy item in the offhand slot, even the default (hidden) components.
 
-Next, the loot table will also copy all components from the item in the `mainhand` to the dummy item in the offhand slot, even the default (hidden) components.
+To check this worked, you can access the item components data manually using the command `/data get entity @s equipment.offhand.components` - you should see all the default components that are usually hidden.
 
 :::info
 
@@ -58,19 +58,17 @@ To solve both this issue and the slot issue, we can summon a temporary armor sta
 ```mcfunction:get_default_components/init.mcfunction
 # Tag the player here so we can find it without the execution context
 tag @s add target_player 
-execute summon minecraft:armor_stand run function namespace:get_default_components/summon 
+execute summon minecraft:armor_stand run function namespace:get_default_components/process 
 tag @s remove target_player
 ```
 
-Next we copy the desired item to it's mainhand. After that, we can use this mainhand slot to provide the "tool" context and copy the dummy item to it's offhand.
-
-Now the only thing we need to do is read the data from the armorstand and kill it.
+Next we copy the desired item to its mainhand. After that, we can use this mainhand slot to provide the "tool" context and copy the dummy item to it's offhand. Then the only thing we need to do is store the data from the armor stand and kill it.
 
 ```mcfunction:get_default_components/process.mcfunction
 # Move the item from the desired player slot onto the armor stand
-item replace entity @s weapon.mainhand from entity @a[tag=target_player] armor.head
+item replace entity @s weapon.mainhand from entity @a[tag=target_player,limit=1] armor.head
 
-# Copy the components to a default item
+# Run the loot table
 loot replace entity @s weapon.offhand fish namespace:get_default_components ~ ~ ~ mainhand
 
 # Copy the components to a result storage
@@ -81,15 +79,11 @@ data modify storage namespace:temp default_components set from entity @s equipme
 kill @s
 ```
 
-Voila, now we can run the function `namespace:get_default_components/init` to get the components from the chosen slot (in this case the head slot).
+Now we can run the function `namespace:get_default_components/init` as a player to get the components from the chosen slot (in this case the head slot). The source slot can be changed by modifying `armor.head` on line 2. The item data components will be stored to the `namespace:default_components` storage, and from here you can access them in your datapack.
 
 :::tip
 
-The source slot can be changed by modifying `armor.head` on line 2. The data components will be stored to the `namespace:default_components` storage in NBT format
-
-:::
-
-In addition, you can also filter for any components using the `include` and `exclude` fields in your loot table. 
+In addition, you can also filter for or filter out any components using the `include` and `exclude` fields in your loot table function. 
 ```json
 {
   "function": "minecraft:copy_components",
@@ -100,6 +94,10 @@ In addition, you can also filter for any components using the `include` and `exc
 }
 ```
 
+:::
+
+
+
 ## Credits
 
-This method was originally discovered by [baphomet42 on the Minecraft Commands discord server](https://discord.com/channels/154777837382008833/157097006500806656/1418032607215620096) and finalized by [Arkiitekk](https://discord.com/channels/935560260725379143/1435909929754955796/1538472517558083624) who informed me about it. Hence I decided to make a guide for this awesome datapack quirk.
+This method was originally discovered by [baphomet42 on the Minecraft Commands discord server](https://discord.com/channels/154777837382008833/157097006500806656/1418032607215620096) and finalized by [Arkiitekk](https://discord.com/channels/935560260725379143/1435909929754955796/1538472517558083624). 


### PR DESCRIPTION
Added a new guide on how to get the default item components from any slot. This is a pretty weird trick so I thought I'd be nice to have here. 

Now I finally understand how this wiki works, I'll probably write more pages as I find some useful.

Anyways, the updated page for 26.3 is already ready so lmk in the future when I can merge that one.